### PR TITLE
implement the changes for the displaced track reconstruction

### DIFF
--- a/packages/reco/ktracker/KalmanFastTracking.cxx
+++ b/packages/reco/ktracker/KalmanFastTracking.cxx
@@ -788,7 +788,8 @@ void KalmanFastTracking::buildGlobalTracks()
             _timers["global_st1"]->stop();
 
             _timers["global_link"]->restart();
-            Tracklet tracklet_best_prob, tracklet_best_vtx;
+            //Tracklet tracklet_best_prob, tracklet_best_vtx;
+            Tracklet tracklet_best_prob;
             for(std::list<Tracklet>::iterator tracklet1 = trackletsInSt[0].begin(); tracklet1 != trackletsInSt[0].end(); ++tracklet1)
             {
 #ifdef _DEBUG_ON
@@ -819,15 +820,15 @@ void KalmanFastTracking::buildGlobalTracks()
 
                 ///Set vertex information - only applied when KF is enabled
                 ///TODO: maybe in the future add a Genfit-based equivalent here, for now leave as is
-                if(enable_KF)
-                {
-                    _timers["global_kalman"]->restart();
-                    SRecTrack recTrack = processOneTracklet(tracklet_global);
-                    _timers["global_kalman"]->stop();
-                    tracklet_global.chisq_vtx = recTrack.getChisqVertex();
+                //if(enable_KF)
+                //{
+                //    _timers["global_kalman"]->restart();
+                //    SRecTrack recTrack = processOneTracklet(tracklet_global);
+                //    _timers["global_kalman"]->stop();
+                //    tracklet_global.chisq_vtx = recTrack.getChisqVertex();
 
-                    if(recTrack.isValid() && tracklet_global.chisq_vtx < tracklet_best_vtx.chisq_vtx) tracklet_best_vtx = tracklet_global;
-                }
+                //    if(recTrack.isValid() && tracklet_global.chisq_vtx < tracklet_best_vtx.chisq_vtx) tracklet_best_vtx = tracklet_global;
+                //}
 
 #ifdef _DEBUG_ON
                 LogInfo("New tracklet: ");
@@ -839,28 +840,28 @@ void KalmanFastTracking::buildGlobalTracks()
                 LogInfo("Comparison I: " << (tracklet_global < tracklet_best_prob));
                 LogInfo("Quality I   : " << acceptTracklet(tracklet_global));
 
-                if(enable_KF)
-                {
-                    LogInfo("Current best by vtx:");
-                    tracklet_best_vtx.print();
+                //if(enable_KF)
+                //{
+                //    LogInfo("Current best by vtx:");
+                //    tracklet_best_vtx.print();
 
-                    LogInfo("Comparison II: " << (tracklet_global.chisq_vtx < tracklet_best_vtx.chisq_vtx));
-                    //LogInfo("Quality II   : " << recTrack.isValid());
-                }
+                //    LogInfo("Comparison II: " << (tracklet_global.chisq_vtx < tracklet_best_vtx.chisq_vtx));
+                //    //LogInfo("Quality II   : " << recTrack.isValid());
+                //}
 #endif
             }
             _timers["global_link"]->stop();
 
-            //The selection logic is, prefer the tracks with best p-value, as long as it's not low-pz
-            if(enable_KF && tracklet_best_prob.isValid() > 0 && 1./tracklet_best_prob.invP > 18.)
-            {
-                tracklet_best[i] = tracklet_best_prob;
-            }
-            else if(enable_KF && tracklet_best_vtx.isValid() > 0) //otherwise select the one with best vertex chisq, TODO: maybe add a z-vtx constraint
-            {
-                tracklet_best[i] = tracklet_best_vtx;
-            }
-            else if(tracklet_best_prob.isValid() > 0) //then fall back to the default only choice
+            ////The selection logic is, prefer the tracks with best p-value, as long as it's not low-pz
+            //if(enable_KF && tracklet_best_prob.isValid() > 0 && 1./tracklet_best_prob.invP > 18.)
+            //{
+            //    tracklet_best[i] = tracklet_best_prob;
+            //}
+            //else if(enable_KF && tracklet_best_vtx.isValid() > 0) //otherwise select the one with best vertex chisq, TODO: maybe add a z-vtx constraint
+            //{
+            //    tracklet_best[i] = tracklet_best_vtx;
+            //}
+            if(tracklet_best_prob.isValid() > 0) //then fall back to the default only choice
             {
                 tracklet_best[i] = tracklet_best_prob;
             }


### PR DESCRIPTION
implement Kun's code (https://cdcvs.fnal.gov/redmine/projects/seaquest-ktracker/repository/revisions/2a8f6204797b6ce142297ea2e158756fdd151552/diff) for reconstructing displaced tracks.

The changes on some reco constants will be done in the separate reco config.

Currently works fine on the pure signal samples https://indico.fnal.gov/event/48513/#5-yongbin. More performance studies ongoing.